### PR TITLE
Allow directory and Json file to exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
 branding:
-  icon: 'tool'
+  icon: 'edit-3'
   color: 'red'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,12 @@
-mkdir ._actionshub_problem-matchers
-cp /yamllint.json ._actionshub_problem-matchers/yamllint.json
-echo "##[add-matcher]._actionshub_problem-matchers/yamllint.json"
+#!/bin/bash
+
+MATCHER_FILE="._actionshub_problem-matchers/yamllint.json"
+
+mkdir -p ._actionshub_problem-matchers
+
+if [[ ! -f ${MATCHER_FILE} ]];then
+    cp /yamllint.json ${MATCHER_FILE}
+fi
+
+echo "##[add-matcher]${MATCHER_FILE}"
 yamllint .


### PR DESCRIPTION
- Fixes the tool icon to: https://feathericons.com/?query=edit-3
- Use -p on mkdir to allow the directory to exist and not fail on edit.

This allows for use in environments where the cache/runner isn't cleared
every time.
