### PR TITLE
feat: Move publishing container and release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,34 +1,31 @@
 ---
 name: Build & Publish container
 'on':
-  push:
-    branches: [main]
+  pull_request:
 
 jobs:
-  publish:
+  build_and_publish:
+    name: Build & Publish to GitHub Container Registry
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
+      packages: write
     steps:
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Code checkout
+        uses: actions/checkout@v3
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -45,15 +42,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@main
-
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.tag_version.outputs.new_tag }}
-            ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Jason Field'
 description: 'Run yamllint on your yaml files with ease'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/actionshub/yamllint:v1.3.0
+  image: docker://ghcr.io/actionshub/yamllint:v1.4.0
 branding:
   icon: 'edit-3'
   color: 'red'


### PR DESCRIPTION
Move the build and publish steps into the publish workflow
Any change that GitHub Actions makes doesn't trigger a new workflow. So
we need to grab the new version from the tag_version step an then
publish using that.

We now publish containers on the pull_request step for testing.

Stop publishing the sha as a tag, no one uses this.

Signed-off-by: Dan Webb <dan.webb@damacus.io>
